### PR TITLE
Added missing ressorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Bundesland: 1=Baden-Württemberg, 2=Bayern, 3=Berlin, 4=Brandenburg, 5=Bremen, 6
 - wirtschaft
 - sport	
 - video
+- investigativ
+- faktenfinder
 
 Ressort/Themengebiet
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Suchergebnisse pro Seite (1-30)
 
 **URL:** https://www.tagesschau.de/api2/{ressort}/
 
-Ressort-spezifische Nachrichten, gefiltert über den Pfad-Parameter **ressort** (z.B. inland, ausland oder wirtschaft) 
+Ressort-spezifische Nachrichten, gefiltert über den Pfad-Parameter **ressort** (z.B. inland, ausland, wirtschaft, sport, video, investigativ, faktenfinder) 
 
 
 ## Channels

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -93,7 +93,9 @@ paths:
                 - ausland
                 - wirtschaft
                 - sport
-                - video		
+                - video
+                - investigativ
+                - faktenfinder
           example: ausland
           description: Ressort/Themengebiet
           required: false

--- a/openapi_en.yaml
+++ b/openapi_en.yaml
@@ -85,7 +85,9 @@ paths:
                 - ausland
                 - wirtschaft
                 - sport
-                - video		
+                - video
+                - investigativ
+                - faktenfinder
           example: ausland
           description: Department/subject area
           required: false


### PR DESCRIPTION
The ressorts "investigativ" and "faktenfinder" are also consumable by the tagesschau api and have been added to the documentation.