### PR TITLE
Add "date" query parameter to "news" endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Aktuelle Nachrichten, die über GET-Parameter gefiltert werden können:
 Bundesland: 1=Baden-Württemberg, 2=Bayern, 3=Berlin, 4=Brandenburg, 5=Bremen, 6=Hamburg, 7=Hessen, 8=Mecklenburg-Vorpommern, 9=Niedersachsen, 10=Nordrhein-Westfalen, 11=Rheinland-Pfalz, 12=Saarland, 13=Sachsen, 14=Sachsen-Anhalt, 15=Schleswig-Holstein, 16=Thüringen. Mehrere Komma-getrennte Angaben möglich (z.B. regions=1,2).
 
 
-**Parameters:** *ressort*
+**Parameter:** *ressort*
 
 - inland
 - ausland
@@ -54,6 +54,10 @@ Bundesland: 1=Baden-Württemberg, 2=Bayern, 3=Berlin, 4=Brandenburg, 5=Bremen, 6
 - faktenfinder
 
 Ressort/Themengebiet
+
+**Parameter**: *date*
+
+Datum der Veröffentlichung. Beispiel: `221231` (=2022-12-31)
 
 
 ## Channels

--- a/README_en.md
+++ b/README_en.md
@@ -43,7 +43,7 @@ Current news that can be filtered via GET parameters:
 State: 1=Baden-Württemberg, 2=Bavaria, 3=Berlin, 4=Brandenburg, 5=Bremen, 6=Hamburg, 7=Hesse, 8=Mecklenburg-Western Pomerania, 9=Lower Saxony, 10=North Rhine-Westphalia, 11= Rhineland-Palatinate, 12=Saarland, 13=Saxony, 14=Saxony-Anhalt, 15=Schleswig-Holstein, 16=Thuringia. Multiple comma-separated specifications possible (e.g. regions=1,2).
 
 
-**Parameters:** *ressort*
+**Parameter:** *ressort*
 
 - inland
 - ausland
@@ -52,6 +52,11 @@ State: 1=Baden-Württemberg, 2=Bavaria, 3=Berlin, 4=Brandenburg, 5=Bremen, 6=Ham
 - video
 
 Department/subject area
+
+
+**Parameter**: *date*
+
+Date of publication. Example: `221231` (=2022-12-31)
 
 
 ## Channels

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -88,6 +88,13 @@ paths:
           example: ausland
           description: Ressort/Themengebiet
           required: false
+        - in: query
+          name: date
+          schema:
+            type: string
+          example: 221231
+          description: Datum der Veröffentlichung
+          required: false
 
   /api2/channels/:
     get:

--- a/openapi_en.yaml
+++ b/openapi_en.yaml
@@ -85,6 +85,14 @@ paths:
           description: Department/subject area
           required: false
 
+        - in: query
+          name: date
+          schema:
+            type: string
+          example: 221231
+          description: Date of publication
+          required: false
+
   /api2/channels:
     get:
       summary: "Current channels"


### PR DESCRIPTION
Hello,

I realized that the `nextPage` property of the response object returned by the `/news` endpoint is simply calling the same URL with a query parameter `date` set to the previous day.

After having successfully tried it with a few past dates, I updated the OpenAPI specs and the READMEs.